### PR TITLE
feat: add pr branch override

### DIFF
--- a/.changeset/tame-flies-count.md
+++ b/.changeset/tame-flies-count.md
@@ -1,0 +1,5 @@
+---
+"@changesets/action": patch
+---
+
+Added possibility to override PR branch name.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This action for [Changesets](https://github.com/atlassian/changesets) creates a 
 - version - The command to update version, edit CHANGELOG, read and delete changesets. Default to `changeset version` if not provided
 - commit - The commit message to use. Default to `Version Packages`
 - title - The pull request title. Default to `Version Packages`
+- branch - The branch name to use. Default to `changeset-release/{{branch}}`
 - setupGitUser - Sets up the git user for commits as `"github-actions[bot]"`. Default to `true`
 - createGithubReleases - A boolean value to indicate whether to create Github releases after `publish` or not. Default to `true`
 - cwd - Changes node's `process.cwd()` if the project is not located on the root. Default to `process.cwd()`

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
   branch:
     description: |
-      The branch override.
+      The branch name to use. Default to `changeset-release/{{branch}}`
     required: false
   title:
     description: The pull request title. Default to `Version Packages`

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: |
       The commit message. Default to `Version Packages`
     required: false
+  branch:
+    description: |
+      The branch override.
+    required: false
   title:
     description: The pull request title. Default to `Version Packages`
     required: false

--- a/src/__snapshots__/run.test.ts.snap
+++ b/src/__snapshots__/run.test.ts.snap
@@ -33,6 +33,72 @@ Array [
 ]
 `;
 
+exports[`version creates simple PR with overwritten branch 1`] = `
+Array [
+  Object {
+    "base": "some-branch",
+    "body": "This PR was opened by the [Changesets release](https://github.com/changesets/action) GitHub action. When you're ready to do a release, you can merge this and publish to npm yourself or [setup this action to publish automatically](https://github.com/changesets/action#with-publishing). If you're not ready to do a release yet, that's fine, whenever you add more changesets to some-branch, this PR will be updated.
+
+
+# Releases
+## simple-project-pkg-a@1.1.0
+
+### Minor Changes
+
+-   Awesome feature
+
+### Patch Changes
+
+-   Updated dependencies
+    -   simple-project-pkg-b@1.1.0
+
+## simple-project-pkg-b@1.1.0
+
+### Minor Changes
+
+-   Awesome feature
+",
+    "head": "custom-release-branch",
+    "owner": "changesets",
+    "repo": "action",
+    "title": "Version Packages",
+  },
+]
+`;
+
+exports[`version creates simple PR with overwritten release branch 1`] = `
+Array [
+  Object {
+    "base": "some-branch",
+    "body": "This PR was opened by the [Changesets release](https://github.com/changesets/action) GitHub action. When you're ready to do a release, you can merge this and publish to npm yourself or [setup this action to publish automatically](https://github.com/changesets/action#with-publishing). If you're not ready to do a release yet, that's fine, whenever you add more changesets to some-branch, this PR will be updated.
+
+
+# Releases
+## simple-project-pkg-a@1.1.0
+
+### Minor Changes
+
+-   Awesome feature
+
+### Patch Changes
+
+-   Updated dependencies
+    -   simple-project-pkg-b@1.1.0
+
+## simple-project-pkg-b@1.1.0
+
+### Minor Changes
+
+-   Awesome feature
+",
+    "head": "custom-release-branch",
+    "owner": "changesets",
+    "repo": "action",
+    "title": "Version Packages",
+  },
+]
+`;
+
 exports[`version does not include any release information if a message with simplified release info exceeds size limit 1`] = `
 Array [
   Object {

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,7 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
         prTitle: getOptionalInput("title"),
         commitMessage: getOptionalInput("commit"),
         hasPublishScript,
+        prBranch: getOptionalInput("branch"),
       });
 
       core.setOutput("pullRequestNumber", String(pullRequestNumber));

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -90,6 +90,46 @@ describe("version", () => {
     expect(mockedGithubMethods.pulls.create.mock.calls[0]).toMatchSnapshot();
   });
 
+  it("creates simple PR with overwritten release branch", async () => {
+    let cwd = f.copy("simple-project");
+    linkNodeModules(cwd);
+
+    mockedGithubMethods.search.issuesAndPullRequests.mockImplementationOnce(
+      () => ({ data: { items: [] } })
+    );
+
+    mockedGithubMethods.pulls.create.mockImplementationOnce(() => ({
+      data: { number: 123 },
+    }));
+
+    await writeChangesets(
+      [
+        {
+          releases: [
+            {
+              name: "simple-project-pkg-a",
+              type: "minor",
+            },
+            {
+              name: "simple-project-pkg-b",
+              type: "minor",
+            },
+          ],
+          summary: "Awesome feature",
+        },
+      ],
+      cwd
+    );
+
+    await runVersion({
+      githubToken: "@@GITHUB_TOKEN",
+      cwd,
+      prBranch: 'custom-release-branch'
+    });
+
+    expect(mockedGithubMethods.pulls.create.mock.calls[0]).toMatchSnapshot();
+  });
+
   it("only includes bumped packages in the PR body", async () => {
     let cwd = f.copy("simple-project");
     linkNodeModules(cwd);

--- a/src/run.ts
+++ b/src/run.ts
@@ -268,10 +268,11 @@ export async function runVersion({
   prBodyMaxCharacters = MAX_CHARACTERS_PER_MESSAGE,
   prBranch,
 }: VersionOptions): Promise<RunVersionResult> {
+  const octokit = github.getOctokit(githubToken);
+
   let repo = `${github.context.repo.owner}/${github.context.repo.repo}`;
   let branch = github.context.ref.replace("refs/heads/", "");
   let versionBranch = prBranch || `changeset-release/${branch}`;
-  let octokit = github.getOctokit(githubToken);
   let { preState } = await readChangesetState(cwd);
 
   await gitUtils.switchToMaybeExistingBranch(versionBranch);

--- a/src/run.ts
+++ b/src/run.ts
@@ -251,6 +251,7 @@ type VersionOptions = {
   commitMessage?: string;
   hasPublishScript?: boolean;
   prBodyMaxCharacters?: number;
+  prBranch?: string;
 };
 
 type RunVersionResult = {
@@ -265,10 +266,11 @@ export async function runVersion({
   commitMessage = "Version Packages",
   hasPublishScript = false,
   prBodyMaxCharacters = MAX_CHARACTERS_PER_MESSAGE,
+  prBranch,
 }: VersionOptions): Promise<RunVersionResult> {
   let repo = `${github.context.repo.owner}/${github.context.repo.repo}`;
   let branch = github.context.ref.replace("refs/heads/", "");
-  let versionBranch = `changeset-release/${branch}`;
+  let versionBranch = prBranch || `changeset-release/${branch}`;
   let octokit = github.getOctokit(githubToken);
   let { preState } = await readChangesetState(cwd);
 
@@ -278,9 +280,9 @@ export async function runVersion({
   let versionsByDirectory = await getVersionsByDirectory(cwd);
 
   if (script) {
-    consle.log('>>>>', script);
+    console.log('>>>>', script);
     const scriptLines = script.split("\n");
-    for (cosnt line of scriptLines) {
+    for (const line of scriptLines) {
       let [versionCommand, ...versionArgs] = line.split(/\s+/);
       await exec(versionCommand, versionArgs, { cwd });
     }


### PR DESCRIPTION
Add prbranch override parameter in order to change versionBranch name, that will be used to create PR into main branch.

Usage example:

```
      - name: Create Pull Request
        uses: changesets-action@v1
        with:
          commit: "chore: 🔖 update changelog"
          title: "chore: 🔖 update changelog"
          branch: "release/main"
          version: |
            pnpm run update-changelog
        env:
```
