### PR TITLE
feat: add ignore changeset property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @changesets/action
 
+## 1.4.3
+
+### Patch Changes
+
+- feat: Add ignore optional property to exclude changesets
+
 ## 1.4.2
 
 ### Patch Changes

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This action for [Changesets](https://github.com/atlassian/changesets) creates a 
 - commit - The commit message to use. Default to `Version Packages`
 - title - The pull request title. Default to `Version Packages`
 - branch - The branch name to use. Default to `changeset-release/{{branch}}`
+- ignore - A comma separated list of packages to ignore in changeset calculations.
 - setupGitUser - Sets up the git user for commits as `"github-actions[bot]"`. Default to `true`
 - createGithubReleases - A boolean value to indicate whether to create Github releases after `publish` or not. Default to `true`
 - cwd - Changes node's `process.cwd()` if the project is not located on the root. Default to `process.cwd()`

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: |
       The branch name to use. Default to `changeset-release/{{branch}}`
     required: false
+  ignore:
+    description: |
+      The project names separated by `,` to ignore in changeset calculation.
+    required: false
   title:
     description: The pull request title. Default to `Version Packages`
     required: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@changesets/action",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "main": "dist/index.js",
   "license": "MIT",
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { runPublish, runVersion } from "./run";
 import readChangesetState from "./readChangesetState";
 
 const getOptionalInput = (name: string) => core.getInput(name) || undefined;
+const getIgnoredChangesets = (ignoredList: string | undefined) => (ignoredList ? ignoredList.split(',') : []);
 
 (async () => {
   let githubToken = process.env.GITHUB_TOKEN;
@@ -33,7 +34,8 @@ const getOptionalInput = (name: string) => core.getInput(name) || undefined;
     `machine github.com\nlogin github-actions[bot]\npassword ${githubToken}`
   );
 
-  let { changesets } = await readChangesetState();
+  const ignoredChangesetProjects = getIgnoredChangesets(getOptionalInput('ignore'));
+  let { changesets } = await readChangesetState(ignoredChangesetProjects);
 
   let publishScript = core.getInput("publish");
   let hasChangesets = changesets.length !== 0;

--- a/src/readChangesetState.ts
+++ b/src/readChangesetState.ts
@@ -8,12 +8,21 @@ export type ChangesetState = {
 };
 
 export default async function readChangesetState(
+  ignoredChangesetProjects: string[] = [],
   cwd: string = process.cwd()
 ): Promise<ChangesetState> {
   let preState = await readPreState(cwd);
   let isInPreMode = preState !== undefined && preState.mode === "pre";
 
-  let changesets = await readChangesets(cwd);
+  let rawChangesets = await readChangesets(cwd);
+
+  console.log("rawChangesets => ", JSON.stringify(rawChangesets));
+
+  let changesets = rawChangesets.filter(changeset =>
+    !changeset.releases.some(release => ignoredChangesetProjects.includes(release.name))
+  );
+
+  console.log("changesets => ", JSON.stringify(changesets));
 
   if (isInPreMode) {
     let changesetsToFilter = new Set(preState.changesets);

--- a/src/readChangesetState.ts
+++ b/src/readChangesetState.ts
@@ -16,13 +16,9 @@ export default async function readChangesetState(
 
   let rawChangesets = await readChangesets(cwd);
 
-  console.log("rawChangesets => ", JSON.stringify(rawChangesets));
-
   let changesets = rawChangesets.filter(changeset =>
     !changeset.releases.some(release => ignoredChangesetProjects.includes(release.name))
   );
-
-  console.log("changesets => ", JSON.stringify(changesets));
 
   if (isInPreMode) {
     let changesetsToFilter = new Set(preState.changesets);

--- a/src/run.ts
+++ b/src/run.ts
@@ -273,7 +273,7 @@ export async function runVersion({
   let repo = `${github.context.repo.owner}/${github.context.repo.repo}`;
   let branch = github.context.ref.replace("refs/heads/", "");
   let versionBranch = prBranch || `changeset-release/${branch}`;
-  let { preState } = await readChangesetState(cwd);
+  let { preState } = await readChangesetState([], cwd);
 
   await gitUtils.switchToMaybeExistingBranch(versionBranch);
   await gitUtils.reset(github.context.sha);


### PR DESCRIPTION
Add additional `ignore` property in order to exclude some changelog from processing.

Config example:

```
      - name: Create Release Pull Request or Publish to npm
        id: changesets
        uses: RomanHotsiy/changesets-action@v1
        with:
          publish: pnpm run release
          commit: "chore(project): 🔖 release new versions"
          title: "chore(project): 🔖 release new versions"
          ignore: "ui,platform"
          version: |
```