### PR TITLE
feat: support multiple changeset directories when deciding to open a release PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This action for [Changesets](https://github.com/atlassian/changesets) creates a 
 - title - The pull request title. Default to `Version Packages`
 - branch - The branch name to use. Default to `changeset-release/{{branch}}`
 - ignore - A comma separated list of packages to ignore in changeset calculations.
+- changesetDirectories - A comma separated list of directories containing `.changeset` directory. Used to check if new changesets are present before opening a release PR. Default to `.`.
 - setupGitUser - Sets up the git user for commits as `"github-actions[bot]"`. Default to `true`
 - createGithubReleases - A boolean value to indicate whether to create Github releases after `publish` or not. Default to `true`
 - cwd - Changes node's `process.cwd()` if the project is not located on the root. Default to `process.cwd()`

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: |
       The project names separated by `,` to ignore in changeset calculation.
     required: false
+  changesetDirectories:
+    description: |
+      Paths to directories containing `.changeset` directory, separated by `,`.
+    required: false
   title:
     description: The pull request title. Default to `Version Packages`
     required: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@changesets/action",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "main": "dist/index.js",
   "license": "MIT",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@changesets/action",
-  "version": "1.4.4",
+  "version": "1.4.3",
   "main": "dist/index.js",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Add a `changesetDirectories` input that accepts a comma separated list of directories that contain the `.changeset` directory. These directories will be checked for new changesets when deciding if a release PR needs to be opened:

```yaml
- name: Create Release Pull Request or Publish to npm
  id: changesets
  uses: RomanHotsiy/changesets-action@v3
  with:
    publish: pnpm run release
    commit: 'elease new versions'
    title: 'release new versions'
    changesetDirectories: '.,packages/my-package'
  
```